### PR TITLE
Fix build on nightly

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
-#![ cfg_attr( nightly, feature( external_doc, doc_cfg    ) ) ]
-#![ cfg_attr( nightly, doc    ( include = "../README.md" ) ) ]
+#![ cfg_attr( nightly, feature( doc_cfg ) ) ]
+#![ cfg_attr( nightly, cfg_attr( nightly, doc = include_str!("../README.md") ) )]
 #![ doc = "" ] // empty doc line to handle missing doc warning when the feature is missing.
 
 #![ doc    ( html_root_url = "https://docs.rs/pharos" ) ]


### PR DESCRIPTION
<!--- When contributing all contributions should branch off the -->
<!--- dev branch as master is only used for releases. -->

<!--- Check CONTRIBUTING.md for more information-->

<!--- Please describe the changes in the PR and the motivation below -->
The build fails on the `nightly` toolchain because of the following error:

```
error[E0557]: feature has been removed
 --> ~/.cargo/registry/src/github.com-1ecc6299db9ec823/pharos-0.5.1/src/lib.rs:1:33
  |
1 | #![ cfg_attr( nightly, feature( external_doc, doc_cfg    ) ) ]
  |                                 ^^^^^^^^^^^^ feature has been removed
  |
  = note: use #[doc = include_str!("filename")] instead, which handles macro invocations

error: aborting due to previous error

For more information about this error, try `rustc --explain E0557`.
error: could not compile `pharos`
```

I think this PR should resolve the issue